### PR TITLE
Change resolution

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -59,10 +59,10 @@ static void write_config() {
 // const static std::string playcmd_start = "youtube-dl -o - \"";
 // const static std::string playcmd_end = "\" | mpv -";
 
-const static std::string max_resolution = "1080";
+const static std::string max_resolution = "1080"; // set maximum resolution here
 const static std::string playcmd_start =
     "mpv --ytdl-format=\"bestvideo[height<=?" + max_resolution +
-    "]+bestaudio/best\"  \"";
+    "]+bestaudio/best\"  \""; // mpv runs youtube-dl with right arguments
 
 // old   const static std::string playcmd_start = "mpv \"";
 // url is placed in middle

--- a/src/config.h
+++ b/src/config.h
@@ -1,65 +1,72 @@
 #ifndef TUITUBE_CONFIG_H
 #define TUITUBE_CONFIG_H
-#include <unordered_map>
-#include <string>
 #include "invidious/instances.h"
+#include <string>
+#include <unordered_map>
 
 namespace config {
-  const static std::string config_file_path = std::string(getenv("HOME")) + "/.config/tuitube/config";
-  static std::unordered_map<std::string, std::string> config;
+const static std::string config_file_path =
+    std::string(getenv("HOME")) + "/.config/tuitube/config";
+static std::unordered_map<std::string, std::string> config;
 
-  static void init() {
+static void init() {
     std::ifstream config_file(config_file_path);
     std::string key;
     while (std::getline(config_file, key)) {
-      std::string value;
-      std::getline(config_file, value);
+        std::string value;
+        std::getline(config_file, value);
 
-      config[key] = value;
+        config[key] = value;
     }
 
     // default values
     if (config.find(std::string("Invidious Instance")) == config.end())
-      config[std::string("Invidious Instance")] = "invidious.snopyta.org";
+        config[std::string("Invidious Instance")] = "invidious.snopyta.org";
     if (config.find(std::string("Instance For Popular Videos")) == config.end())
-      config[std::string("Instance For Popular Videos")] = "invidious.snopyta.org";
+        config[std::string("Instance For Popular Videos")] =
+            "invidious.snopyta.org";
     if (config.find(std::string("Video Source")) == config.end())
-      config[std::string("Video Source")] = "Invidious";
-  }
+        config[std::string("Video Source")] = "Invidious";
+}
 
-  static std::string get_value(const std::string& key) {
+static std::string get_value(const std::string &key) {
     if (config[key].empty())
-      config[key] = "0";
+        config[key] = "0";
 
     if (config[key] == "fastest") {
-      return invidious::instances::get_fastest_instance();
+        return invidious::instances::get_fastest_instance();
     }
 
     return config[key];
-  }
+}
 
-  static void set_value(const std::string& key, const std::string& value) {
+static void set_value(const std::string &key, const std::string &value) {
     config[key] = value;
-  }
+}
 
-  static void write_config() {
+static void write_config() {
     std::ofstream file;
     file.open(config_file_path.c_str());
 
-    for (const auto& setting : config) {
+    for (const auto &setting : config) {
         file << setting.first << std::endl << setting.second << std::endl;
     }
 
     file.close();
-  }
-
-    // use these if your mpv cant play web videos
-    // const static std::string playcmd_start = "youtube-dl -o - \"";
-    // const static std::string playcmd_end = "\" | mpv -";
-
-    const static std::string playcmd_start = "mpv \"";
-    // url is placed in middle
-    const static std::string playcmd_end = "\"";
 }
 
-#endif //TUITUBE_CONFIG_H
+// use these if your mpv cant play web videos
+// const static std::string playcmd_start = "youtube-dl -o - \"";
+// const static std::string playcmd_end = "\" | mpv -";
+
+const static std::string max_resolution = "1080";
+const static std::string playcmd_start =
+    "mpv --ytdl-format=\"bestvideo[height<=?" + max_resolution +
+    "]+bestaudio/best\"  \"";
+
+// old   const static std::string playcmd_start = "mpv \"";
+// url is placed in middle
+const static std::string playcmd_end = "\"";
+} // namespace config
+
+#endif // TUITUBE_CONFIG_H


### PR DESCRIPTION
Hello djt3,

I fixed the following issue: youtube-dl defaults to the best quality. Videos might have a higher resolution than the screen they are watched on, this leads to flickering, a waste of energy, computing resources and mobile broadband data. Instead i'd like to stream a video in an adequate resolution. My fix solves this problem:

I added a line in config.h which allows the user to set the maximum resolution during compile time. After this change tuitube runs mpv with a resolution parameter, which itself instructs youtube-dl to download the best feasible resolution of a given video not exceeding the resolution value set during compile time. A future change might recognize the screen resolution, or read a preferred value from a config file, but I didn't look into it for the sake of simplicity.

Lines 62 to 65 src/config.h are important, easy as pie:
```
const static std::string max_resolution = "1080"; // set maximum resolution here
const static std::string playcmd_start =
    "mpv --ytdl-format=\"bestvideo[height<=?" + max_resolution + "]+bestaudio/best\"  \""; 
    // mpv runs youtube-dl with right arguments
```



Have a nice day

Sebastian